### PR TITLE
Modify Pi0 cursor size and step

### DIFF
--- a/test_com_v6.py
+++ b/test_com_v6.py
@@ -143,7 +143,7 @@ class DeviceInfo:
 
 # ラズパイ群（4台）
 devices: Dict[int, DeviceInfo] = {
-    0: DeviceInfo(0, "192.168.10.1", RED, [2, 2], (2, 9, 9 , 1), False, True, 2, 2),
+    0: DeviceInfo(0, "192.168.10.1", RED, [2, 2], (2, 9, 9 , 1), False, True, 1, 1),
     1: DeviceInfo(1, "192.168.10.2", GREEN, [2, 2], (3, 0, 9, 9), False, True, 1, 1),
     2: DeviceInfo(2, "192.168.10.3", BLUE, [2, 2], (9, 9, 0, 3), False, True, 1, 1),
     3: DeviceInfo(3, "192.168.10.4", YELLOW, [2, 2], (9, 2, 1, 9), False, True, 1, 1),


### PR DESCRIPTION
## Summary
- use a 1x1 cursor for Raspberry Pi 0
- move Pi 0 in single-step increments

## Testing
- `python -m py_compile test_com_v6.py`


------
https://chatgpt.com/codex/tasks/task_e_688788a146dc83298d1b752a9f3ab0d1